### PR TITLE
change import value in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ python3 -m playwright install --with-deps
 
 ```python
 from playwright.sync_api import sync_playwright
-from axe_core_python.sync_playwright import Axe
+from axe_playwright_python.sync_playwright import Axe
 
 axe = Axe()
 


### PR DESCRIPTION
readme has `from axe_core_python` but your module is named `axe_playwright_python`