### PR TITLE
Fix issue with serializing options, add test, configure pytest

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,9 @@
 {
     "python.linting.flake8Enabled": true,
-    "python.linting.enabled": true
+    "python.linting.enabled": true,
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
 }

--- a/axe_playwright_python/base.py
+++ b/axe_playwright_python/base.py
@@ -33,7 +33,7 @@ class AxeBase(ABC):
             args_list.append(repr(context))
         # If options is passed, add to args
         if options:
-            args_list.append(str(options))
+            args_list.append(json.dumps(options))
         # Add comma delimiter only if both parameters are passed
         args = ",".join(args_list)
 

--- a/tests/test_axe_sync_playwright.py
+++ b/tests/test_axe_sync_playwright.py
@@ -36,6 +36,13 @@ def webkit_page():
         browser.close()
 
 
+def _perform_axe_run(page):
+    page.goto("file://" + str(TEST_FILE_PATH))
+    axe = Axe()
+    results = axe.run(page=page)
+    return results.response
+
+
 def test_run_axe_sample_page_firefox(firefox_page):
     """Run axe against sample page and verify JSON output is as expected."""
     data = _perform_axe_run(firefox_page)
@@ -66,8 +73,18 @@ def test_run_axe_sample_page_webkit(webkit_page):
     assert len(data["violations"]) == 9
 
 
-def _perform_axe_run(page):
-    page.goto("file://" + str(TEST_FILE_PATH))
+def test_run_axe_detects_region_violation(chromium_page):
+    """Baseline check confirming region violation is reported by default."""
+    chromium_page.goto("file://" + str(TEST_FILE_PATH))
     axe = Axe()
-    results = axe.run(page=page)
-    return results.response
+
+    # First run with default options
+    results = axe.run(page=chromium_page)
+    violation_ids = {violation["id"] for violation in results.response["violations"]}
+    assert "region" in violation_ids
+
+    # Now run again with region rule disabled
+    options = {"rules": {"region": {"enabled": False}}}
+    results = axe.run(page=chromium_page, options=options)
+    violation_ids = {violation["id"] for violation in results.response["violations"]}
+    assert "region" not in violation_ids


### PR DESCRIPTION
Fixes #15

This pull request fixes argument formatting for options passed to scripts, and also improved the VS code testing/linting configuration.

**Bug Fixes and Improvements:**

* Changed the formatting of the `options` argument in `_format_script_args` (in `axe_playwright_python/base.py`) to use `json.dumps` instead of `str`, ensuring correct serialization of options for script execution.

**Test Enhancements:**

* Added a new test, `test_run_axe_detects_region_violation`, to verify that the "region" accessibility violation is detected by default and can be disabled via options. This improves coverage for rule toggling behavior in the `Axe` integration.

**Testing and Linting Configuration:**

* Updated `.vscode/settings.json` to enable pytest for testing, disable unittest, and specify the `tests` directory for test discovery. This streamlines the development workflow for Python testing and ensures consistency in test execution.
