### PR TITLE
Fix URLs linked in further reading

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ and [Playwright](https://playwright.dev/python/docs/intro).
 
 ### Further Reading & More
 - ["Automated accessibility audits" - Pamela Fox (North Bay Python 2023)](https://www.youtube.com/watch?v=J-4Qa6PSomM&pp=ygUUcGFtZWxhIGZveCBub3J0aCBiYXk%3D)
-- [Using Python to Fix my Accessibility Night of a Website](https://kjaymiller.com/blog/using-python-to-fix-my-accessibility-nightmare-of-a-website.html) & [Website Accessibility Audit Reports via GH Actions](https://kjaymiller.com/blog/website-accessibility-audit-reports-via-gh-actions.html) by [Jay Miller](https://github.com/kjaymiller)
+- [Using Python to Fix my Accessibility Night of a Website](https://kjaymiller.com/blog/using-python-to-fix-my-sites-accessibility.html) &
+    [Website Accessibility Audit Reports via GH Actions](https://kjaymiller.com/blog/gh-action-accessibility.html)
+    by [Jay Miller](https://github.com/kjaymiller)
 
 
 ## Dependencies


### PR DESCRIPTION
URLs of the Jay Miller blog posts referenced under Further Reading changed and current hrefs point to 404 pages.