### PR TITLE
Add maintenance script for axe-core installation/update

### DIFF
--- a/.github/scripts/install-axe.sh
+++ b/.github/scripts/install-axe.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+VERSION=${1:+@${1}}
+
+TMP=/tmp
+PKG_DATA=$(
+  npm pack --json --pack-destination "${TMP}" --ignore-scripts \
+    --registry=https://registry.npmjs.org "axe-core${VERSION}"
+)
+
+TARFILE=$(jq -r '.[].filename' <<< "${PKG_DATA}")
+DISTFILE=$(
+  jq -r '.[].files[].path | select(test("axe\\.min\\.js$"))' \
+    <<< "${PKG_DATA}"
+)
+tar -Oxzf "${TMP}/${TARFILE}" "package/${DISTFILE}" > \
+  axe_playwright_python/axe.min.js
+
+rm -f "${TMP}/${TARFILE}"


### PR DESCRIPTION
This might come in handy for updating the bundled Axe distro.

```bash
  bash .github/scripts/install-axe.sh 4.12.0
```

The version argument can be omitted.

```bash
  bash .github/scripts/install-axe.sh
```  