### PR TITLE
Add GH Workflow running scheduled Axe update checks

### DIFF
--- a/.github/scripts/check-axe-updates.sh
+++ b/.github/scripts/check-axe-updates.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+RLS=$(
+  curl -sf "https://api.github.com/repos/dequelabs/axe-core/releases?per_page=3"
+)
+
+COOLDOWN=$(( 5*24*3600 ))
+CANDIDATE=$(
+  jq -r '[.[] | select(.published_at | fromdate < now - '"${COOLDOWN}"')] | first' \
+   <<< "${RLS}"
+)
+
+CUR=$(
+  sed -n 's/^\/\*! axe \(v[0-9.]*\)/\1/p;q' \
+    axe_playwright_python/axe.min.js
+)
+CAND=$(jq -r '.tag_name' <<< "${CANDIDATE}")
+
+[[ "${CUR}" == "${CAND}" ]] || echo "${CAND#v}"

--- a/.github/scripts/install-axe.sh
+++ b/.github/scripts/install-axe.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+VERSION=${1:+@${1}}
+
+TMP=/tmp
+PKG_DATA=$(
+  npm pack --json --pack-destination "${TMP}" --ignore-scripts \
+    --registry=https://registry.npmjs.org "axe-core${VERSION}"
+)
+
+TARFILE=$(jq -r '.[].filename' <<< "${PKG_DATA}")
+DISTFILE=$(
+  jq -r '.[].files[].path | select(test("axe\\.min\\.js$"))' \
+    <<< "${PKG_DATA}"
+)
+tar -Oxzf "${TMP}/${TARFILE}" "package/${DISTFILE}" > \
+  axe_playwright_python/axe.min.js
+
+rm -f "${TMP}/${TARFILE}"

--- a/.github/workflows/update-axe.yaml
+++ b/.github/workflows/update-axe.yaml
@@ -1,0 +1,23 @@
+---
+
+name: Check for Axe updates
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 1'
+
+jobs:
+  check-updates:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: check for axe update && nag about it
+        run: |-
+          version=$(bash .github/scripts/check-axe-updates.sh)
+          [[ -z "${version}" ]] && exit 0
+          echo "found new version ${version}" >> /dev/stderr
+          bash .github/scripts/install-axe.sh "${version}"
+          git diff --stat --exit-code
+
+...


### PR DESCRIPTION
This is a follow-up on #21, which introduces a simple script for updating the bundled Axe distro as described in #12 . However, considering some recent incidents, it might not be such a good idea to just download and ship whatever latest version happens to be available for some package on the npm registry. Therefore, this PR proposes a means of checking the Github releases API for recent `axe-core` releases that have been up longer than a certain (for the time being hardcoded) cooldown period in order to determine a safe version to upgrade to.

This takes place in the bash script `.github/scripts/check-axe-updates.sh`. It looks up the most recent `axe-core` release older than the cooldown period and compares it to the Axe version currently bundled. If these two differ, the script spits out the new version. This output can then be passed to the `install-axe.sh` script proposed in #21.

A new CI workflow `update-axe.yaml` would try this once a week and fail if an update could be installed. See example: https://github.com/JKatzwinkel/axe-playwright-python-updates/actions/runs/27504618061/job/81293488987